### PR TITLE
Solve Unix format error in cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -263,3 +263,4 @@ function paramSearchFill(params, cb) {
 
   return cb(output);
 }
+


### PR DESCRIPTION
solve "env: node\r: No such file or directory" error in cli.js
problem here on Mac OS and Linux
please publish new beta version

https://github.com/nwjs-community/nw-builder/issues/75#issuecomment-55108563
> I resolved this issue converting the line ending from DOS to UNIX format.
> In vim I used this command:
> :set ff=unix